### PR TITLE
fix(delegation): stop "Worker has been terminated" crashes + release 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] — 2026-06-10
+
+### Fixed
+- **Sub-agent delegation no longer crashes the whole session with `Worker has been terminated`.** When a delegated sub-agent session ends or is aborted, the OpenCode runtime can `write()` to an already-destroyed stream, throwing an unhandled `Cannot call write after a stream was destroyed` (`ERR_STREAM_DESTROYED`). With no `unhandledRejection` listener, Bun terminated the worker running the `task` tool, killing the parent session. The error originates entirely in the runtime bundle (`/$bunfs/...`) with no plugin frames, and OpenCode does not persist it to its file logs. Added a narrowly-scoped process guard (`src/shared/runtime-stream-teardown-guard.ts`) that swallows only this benign stream-teardown race and re-throws every other rejection, so genuine bugs still surface. Upstream OpenCode bug; this is a plugin-side mitigation.
+
+### Changed
+- Bumped `@opencode-ai/plugin` and `@opencode-ai/sdk` to `^1.17.1` to match the OpenCode runtime.
+
 ## [0.2.7] — 2026-06-10
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,8 @@
       "name": "@hiai-gg/hiai-opencode",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
-        "@opencode-ai/plugin": "^1.16.2",
-        "@opencode-ai/sdk": "^1.16.2",
+        "@opencode-ai/plugin": "1.17.1",
+        "@opencode-ai/sdk": "1.17.1",
         "bun-pty": "^0.4.8",
         "commander": "^13.1.0",
         "diff": "^7.0.0",
@@ -64,9 +64,9 @@
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.16.2", "", { "dependencies": { "@opencode-ai/sdk": "1.16.2", "effect": "4.0.0-beta.74", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.3.2", "@opentui/keymap": ">=0.3.2", "@opentui/solid": ">=0.3.2" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-FaZhVXrbz93xsdGLCtarRDTeqFt8AkLfh8B34tFBj6G4HXVmKSgBwVXmtELKKC+08xMtawBC9hshiMbXryv6cg=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.17.1", "", { "dependencies": { "@opencode-ai/sdk": "1.17.1", "effect": "4.0.0-beta.74", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.3.4", "@opentui/keymap": ">=0.3.4", "@opentui/solid": ">=0.3.4" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-LoKYrJfVGLCmOXyuIMNsVsO8rkAREyiQWDNvQUUMul5h7uEofsPsytd/jUPa6dJ5GZ9OzYAFyybj7IdnhpFrjA=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.16.2", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-Z/xZ7q79dYeE0afqIk/yFEcRNGEQFcE+H8ssYivUiy+xGZ1mGwT72jpaQZKBwPn3JH4sRCu4KA2lcktBQfcOjg=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.1", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-YTMtG3qCWgF37M9suOL5KpQTKU2Ibkd0/eKLS4tEIXe1S2wvUQ+/Hi1QARw4SoD6cy6+KUINvyo6dkhFEo7WLw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiai-gg/hiai-opencode",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Unified OpenCode plugin — 14-agent model (9 visible + 5 hidden) with MCP integrations, browser automation, bundled skills, 150+ design systems, LSP, and safer defaults.",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -92,8 +92,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "@opencode-ai/plugin": "^1.16.2",
-    "@opencode-ai/sdk": "^1.16.2",
+    "@opencode-ai/plugin": "^1.17.1",
+    "@opencode-ai/sdk": "^1.17.1",
     "bun-pty": "^0.4.8",
     "commander": "^13.1.0",
     "diff": "^7.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
   getSkillPluginConflictWarning,
 } from "./shared/external-plugin-detector";
 import { PLUGIN_NAME } from "./shared/plugin-identity";
+import { installRuntimeStreamTeardownGuard } from "./shared/runtime-stream-teardown-guard";
 import { autoExportStaticMcpJson } from "./shared/mcp-static-export";
 import {
   warnIfListPluginEntry,
@@ -105,6 +106,7 @@ const HiaiOpenCodePlugin: Plugin = async (ctx) => {
   log("[HiaiOpenCodePlugin] ENTRY - plugin loading", {
     directory: ctx.directory,
   });
+  installRuntimeStreamTeardownGuard();
   warnIfListPluginEntry(ctx.directory);
 
   const skillPluginCheck = detectExternalSkillPlugin(ctx.directory);

--- a/src/shared/runtime-stream-teardown-guard.ts
+++ b/src/shared/runtime-stream-teardown-guard.ts
@@ -1,0 +1,57 @@
+import { logWarn } from "./logger";
+
+/**
+ * Suppresses a benign teardown race in the OpenCode runtime that surfaces
+ * during agent delegation.
+ *
+ * When a delegated sub-agent session ends or is aborted, the runtime can try to
+ * `write()` to a stream that was already destroyed, producing an unhandled
+ * rejection like `Cannot call write after a stream was destroyed`. With no
+ * `unhandledRejection` listener present, Bun terminates the worker running the
+ * tool — observed as `Worker has been terminated`, which kills the whole parent
+ * session.
+ *
+ * The error originates entirely inside the runtime bundle (`/$bunfs/...`) with
+ * no plugin frames, so it is not actionable from here and is safe to swallow.
+ * Every other unhandled rejection is re-thrown to preserve the default
+ * crash-on-real-bug behavior — we only neutralize this specific race.
+ */
+function isBenignStreamTeardown(reason: unknown): boolean {
+  const err = reason as
+    | { message?: string; code?: string; stack?: string }
+    | undefined;
+  const message = err?.message ?? "";
+  const code = err?.code ?? "";
+  const stack = err?.stack ?? "";
+
+  if (code === "ERR_STREAM_DESTROYED") return true;
+  if (message.includes("write after a stream was destroyed")) return true;
+  // Some hits arrive with an empty message; identify them by the runtime
+  // stream-write call signature instead.
+  return (
+    stack.includes("internal:streams/writable") && stack.includes("doWrite")
+  );
+}
+
+export function installRuntimeStreamTeardownGuard(): void {
+  const g = globalThis as { __hiaiStreamTeardownGuardInstalled?: boolean };
+  if (g.__hiaiStreamTeardownGuardInstalled) {
+    return;
+  }
+  g.__hiaiStreamTeardownGuardInstalled = true;
+
+  process.on("unhandledRejection", (reason: unknown) => {
+    if (isBenignStreamTeardown(reason)) {
+      const message =
+        (reason as { message?: string } | undefined)?.message ??
+        String(reason);
+      logWarn(
+        "[delegation] suppressed benign OpenCode runtime stream-teardown race",
+        { message },
+      );
+      return;
+    }
+    // Not our race — restore default behavior so genuine bugs still surface.
+    throw reason;
+  });
+}


### PR DESCRIPTION
## What

Delegated sub-agent runs (the `task` tool) crashed the **whole parent session** with `Worker has been terminated`.

## Root cause

An OpenCode **runtime** teardown race — not plugin logic. When a delegated sub-agent session ends/aborts, the runtime `write()`s to an already-destroyed stream, throwing an unhandled:

```
Error: Cannot call write after a stream was destroyed
    at _write (internal:streams/writable:240:29)
    at write (/$bunfs/root/chunk-easjaeyr.js:32:14071)
    at doWrite (/$bunfs/root/chunk-easjaeyr.js:4:1687)
    at processTicksAndRejections
```

The entire stack is inside the runtime bundle (`/$bunfs/...`); **no plugin frames**. With no `unhandledRejection` listener, Bun terminates the worker running the tool → the parent session dies. OpenCode writes **nothing** to its file logs (0 `level=ERROR`), so it was invisible — caught only via a temporary process-level listener.

## Fix

`src/shared/runtime-stream-teardown-guard.ts` — a process guard that swallows **only** this benign stream-teardown race (logs via `logWarn`) and **re-throws every other rejection**, so genuine bugs still surface. Wired into plugin init.

This is a plugin-side **mitigation**; the real bug is upstream in OpenCode (stream write-after-destroy on sub-agent session teardown).

## Commits
- `fix(delegation):` the guard (the actual fix)
- `chore(deps):` `@opencode-ai/plugin` + `sdk` → `^1.17.1` (align to runtime; unrelated)
- `chore(release): 0.2.8`

## Verification
- typecheck ✅ · biome lint ✅ · full minified build ✅ (2.69 MB < 3 MB guard)
- Live repro before fix: parent session died; instrumentation captured the stack above 3×/delegation.
- After fix: benign race logged, session survives.

## Note on release
Tag `v0.2.8` (triggers npm publish + GitHub release) intentionally **not** pushed here — left as a deliberate manual step.