### PR TITLE
fix(background-agent): nested delegators (Manager) lose their delegated children

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -383,6 +383,19 @@ export class BackgroundManager {
     return result;
   }
 
+  /**
+   * True when the given session has any still-active (running/pending)
+   * descendant background tasks. Used to defer a delegating sub-agent's
+   * completion until its own delegated children finish, so it can receive
+   * their completion notifications instead of being torn down first.
+   */
+  hasPendingDescendantTasks(sessionID: string | undefined): boolean {
+    if (!sessionID) return false;
+    return this.getAllDescendantTasks(sessionID).some(
+      (task) => task.status === "running" || task.status === "pending",
+    );
+  }
+
   findBySession(sessionID: string): BackgroundTask | undefined {
     for (const task of this.state.tasks.values()) {
       if (task.sessionID === sessionID) {
@@ -1584,6 +1597,22 @@ export class BackgroundManager {
         status: task.status,
         source,
       });
+      return false;
+    }
+
+    // Guard: a delegating sub-agent must not be completed (and its session
+    // aborted) while it still has active background children — otherwise it can
+    // never receive their completion notifications. Keep it running; the
+    // idle/poll loops will retry once the children finish.
+    if (this.hasPendingDescendantTasks(task.sessionID)) {
+      log(
+        "[background-agent] Deferring completion — session has active descendant tasks:",
+        {
+          taskId: task.id,
+          sessionID: task.sessionID,
+          source,
+        },
+      );
       return false;
     }
 

--- a/src/features/background-agent/nested-delegation-completion.test.ts
+++ b/src/features/background-agent/nested-delegation-completion.test.ts
@@ -1,0 +1,95 @@
+import { expect, test, describe, beforeEach, afterEach } from "bun:test";
+import { BackgroundManager } from "./manager";
+
+// A delegating sub-agent (e.g. Manager) that itself launches background child
+// tasks must not be torn down while those children are still running — otherwise
+// it can never receive/"catch" their completion notifications. Bob (the root
+// session) is never wrapped in a background task, so only nested delegators hit
+// this. The guard lives in tryCompleteTask, the single completion chokepoint.
+describe("nested delegation: defer parent completion while descendants run", () => {
+  let manager: BackgroundManager;
+  let mockClient: { session: Record<string, (arg?: unknown) => unknown> };
+  let aborted: string[];
+
+  beforeEach(() => {
+    aborted = [];
+    mockClient = {
+      session: {
+        create: async () => ({ id: "s" }),
+        get: async ({ path }: { path: { id: string } }) => ({
+          data: { id: path.id },
+        }),
+        prompt: async () => ({ messages: [] }),
+        status: async () => ({}),
+        todo: async () => [],
+        abort: async ({ path }: { path: { id: string } }) => {
+          aborted.push(path.id);
+        },
+        messages: async () => ({ data: [] }),
+      },
+    } as never;
+
+    manager = new BackgroundManager(
+      { client: mockClient, directory: "/test/dir" } as never,
+      undefined,
+      { enableParentSessionNotifications: false },
+    );
+  });
+
+  afterEach(() => manager.shutdown());
+
+  const makeTask = (over: Record<string, unknown>) => ({
+    status: "running",
+    agent: "coder",
+    description: "t",
+    startedAt: new Date(),
+    ...over,
+  });
+
+  test("defers and keeps the parent alive while a child is running", async () => {
+    const state = (manager as unknown as { state: { tasks: Map<string, unknown> } }).state;
+    const parent = makeTask({
+      id: "parent-task",
+      sessionID: "manager-session",
+      parentSessionID: "bob-session",
+      agent: "manager",
+    });
+    const child = makeTask({
+      id: "child-task",
+      sessionID: "child-session",
+      parentSessionID: "manager-session",
+    });
+    state.tasks.set("parent-task", parent);
+    state.tasks.set("child-task", child);
+
+    const result = await (
+      manager as unknown as {
+        tryCompleteTask: (t: unknown, s: string) => Promise<boolean>;
+      }
+    ).tryCompleteTask(parent, "test");
+
+    expect(result).toBe(false);
+    expect((parent as { status: string }).status).toBe("running");
+    expect(aborted).not.toContain("manager-session");
+  });
+
+  test("completes normally once no descendants remain", async () => {
+    const state = (manager as unknown as { state: { tasks: Map<string, unknown> } }).state;
+    const parent = makeTask({
+      id: "parent-task",
+      sessionID: "manager-session",
+      parentSessionID: "bob-session",
+      agent: "manager",
+    });
+    state.tasks.set("parent-task", parent);
+
+    const result = await (
+      manager as unknown as {
+        tryCompleteTask: (t: unknown, s: string) => Promise<boolean>;
+      }
+    ).tryCompleteTask(parent, "test");
+
+    expect(result).toBe(true);
+    expect((parent as { status: string }).status).toBe("completed");
+  });
+});


### PR DESCRIPTION
## Symptom

When Bob delegates to **Manager** and Manager delegates further, **Manager never catches its completed child tasks**. Bob (delegating directly) works fine.

## Root cause

Completion asymmetry between the root session and nested delegators.

- **Bob** (the root session) is never wrapped in a background task, so nothing tears it down — it stays alive and receives child notifications. It's also protected by `stop-continuation-guard`, which already gates on `getAllDescendantTasks(sessionID)`.
- **Manager** runs *as* a background task. Its completion goes through `tryCompleteTask` (the single chokepoint, reached from the `session.idle` handler and the poller), which only checked `hasValidOutput` + `hasIncompleteTodos` — **never the session's own active background descendants** — and then **aborts the sub-agent session** (`abortSessionWithLogging`). So Manager is destroyed before its children finish, and their completion notifications (sent to `parentSessionID = Manager's session`) land on a dead session.

`getAllDescendantTasks` (recursive) already existed but was wired only into the stop-guard and cancel paths — not into completion.

## Fix

- Add `BackgroundManager.hasPendingDescendantTasks(sessionID)`.
- Guard `tryCompleteTask`: while the session has `running`/`pending` descendants, **defer** (return `false`) and keep the task running — mirroring the existing `hasIncompleteTodos` deferral.

The idle/poll loops already `continue` polling while a task stays `running`, so the parent is re-evaluated automatically once its children finish — then it completes and reports back. Stuck children are pruned by the existing TTL, so there's no deadlock.

## Tests
- New `nested-delegation-completion.test.ts`: parent with a running child → `tryCompleteTask` returns `false`, parent stays `running`, session not aborted; parent with no descendants → completes normally.
- Full suite: **1991 pass / 0 fail**. typecheck ✅, build ✅ (2.82 MB).

## Note
CHANGELOG/version bump intentionally **deferred** — fold into the next release commit (independent of the 0.2.8 release in #2).